### PR TITLE
Leave source-paths in the project.clj so classpath roots are preserved properly.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-repack "0.2.5"
+(defproject org.clojars.rickmoynihan/lein-repack "0.2.5-SNAPSHOT"
   :description "Repack your project for deployment"
   :url "https://www.github.com/zcaudate/lein-repack"
   :license {:name "The MIT License"

--- a/src/leiningen/repack/split.clj
+++ b/src/leiningen/repack/split.clj
@@ -53,12 +53,11 @@
                   flatten
                   distinct
                   (map :id)))))
-                  
 (comment
   (require '[leiningen.repack.manifest :as manifest])
   (def project (project/read "example/hara/project.clj"))
-  (def manifest (manifest/create-manifest project))
+  (def manifest (manifest/create project))
   (clean project)
   (create-scaffold project manifest)
-  (create-source-files project manifest)
+  (create-files project manifest)
   (create-project-clj-files project manifest))

--- a/src/leiningen/repack/split/rewrite.clj
+++ b/src/leiningen/repack/split/rewrite.clj
@@ -56,7 +56,7 @@
       (replace-project-value :dependencies
                              (-> manifest :branches (get name) :dependencies))
       (remove-project-key :profiles)
-      (remove-project-key :source-paths)
+      ;;(remove-project-key :source-paths) ;; Leave source-paths in the project.clj so classpath roots are preserved properly.
       (remove-project-key :repack)
       z/print-root
       with-out-str))


### PR DESCRIPTION
This fix preserves the `:source-path` in the `project.clj` file in the repacked dependencies.

The reason I think this is useful is that repack currently doesn't afford much control over the number of dependencies that are generated.  i.e. it will generate packages for namespaces that don't really make much sense for a user to depend on alone.

I'd like a more curated set on grafter ( http://grafter.org/ )  which is why I have the different top level packages specified in my src tree.  Having direct control over this via the project.clj file would be ideal, as the approach of creating subfolders in src/ feels a bit hacky.

Regardless I thought I'd send you a PR on the off chance its useful... but I suspect the feature might be implemented in a nicer manner.

